### PR TITLE
Draggable object outside parent container

### DIFF
--- a/src/DragAndDropSupportWidget/widget/DraggableWidget.js
+++ b/src/DragAndDropSupportWidget/widget/DraggableWidget.js
@@ -35,7 +35,8 @@ require([
         _setupEvents: function () {
             // http://api.jqueryui.com/draggable/
             var options = {
-                containment: this.dragContainment || false,
+                appendTo: "body",
+				containment: this.dragContainment || false,
                 revert: "invalid",
                 helper: this.makeClone ? "clone" : "original"
             };


### PR DESCRIPTION
Added: "appendTo: 'body'" to options of draggable container.

When dragging a draggable-container outside its parent container which has been placed in a scroll-container (with overflow-auto/scroll), the container disappears behind the target scroll-container. By adding the option appendTo: body the container remains on top.